### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/openapi-linter.yml
+++ b/.github/workflows/openapi-linter.yml
@@ -21,3 +21,13 @@ jobs:
 
       - name: Validate OpenAPI Specification
         run: redocly lint ./xkcd-data-hub-api.yaml --format=stylish
+
+  dependabot_auto_merge:
+    needs: validate
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
+    secrets:
+      GITHUB_PAT: ${{ secrets.REVIEWER_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add the shared Dependabot auto-merge workflow after OpenAPI validation
- configure the workflow to use REVIEWER_GITHUB_TOKEN

## Validation
- parsed the workflow YAML locally
- verified REVIEWER_GITHUB_TOKEN is configured as a repository Actions secret