### PR TITLE
Fix Dependabot auto-merge checks

### DIFF
--- a/.github/workflows/openapi-linter.yml
+++ b/.github/workflows/openapi-linter.yml
@@ -25,9 +25,29 @@ jobs:
   dependabot_auto_merge:
     needs: validate
     if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
-    secrets:
-      GITHUB_PAT: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approval for Dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Merge Dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+        run: gh pr merge --admin --rebase "$PR_URL"


### PR DESCRIPTION
## Summary
- keep Dependabot auto-merge in the OpenAPI validation workflow
- replace the shared reusable workflow with local steps for this repo
- rely on needs: validate instead of gh pr checks --required, which reports no required checks for this PR/ruleset setup

## Validation
- parsed workflow YAML locally
- verified REVIEWER_GITHUB_TOKEN is configured as a Dependabot secret

Root cause: the first failure was an Actions-vs-Dependabot secret mismatch; after setting the Dependabot secret, the shared workflow still failed at gh pr checks --required with: no required checks reported on the Dependabot branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation for dependency management processes.

---

**Note:** This release includes internal infrastructure improvements with no direct user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/xkcd-data-hub-api/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->